### PR TITLE
Rename param resolution_fixed -> fixed_resolution

### DIFF
--- a/params/ydlidar.yaml
+++ b/params/ydlidar.yaml
@@ -8,7 +8,7 @@ ydlidar_ros2_driver_node:
     device_type: 0
     sample_rate: 9
     abnormal_check_count: 4
-    resolution_fixed: true
+    fixed_resolution: true
     reversion: true
     inverted: true
     auto_reconnect: true


### PR DESCRIPTION
The example `params/ydlidar.yaml` file has a `resolution_fixed` parameter, which should be named `fixed_resolution` as per the code here:

https://github.com/YDLIDAR/ydlidar_ros2_driver/blob/2e095da315aec0a0bc5aaac12082cb9d1f97f8b5/src/ydlidar_ros2_driver_node.cpp#L88-L92

This is an important setting when using slam_toolbox, which expects that each message on the `/scan` topic will have the same number of points.