### PR TITLE
Bugfix/service flooding errors

### DIFF
--- a/src/ydlidar_ros2_driver_node.cpp
+++ b/src/ydlidar_ros2_driver_node.cpp
@@ -190,7 +190,7 @@ int main(int argc, char *argv[]) {
 
     LaserScan scan;//
 
-    if (laser.isScanning){
+    if (laser.isScanning()){
       if (laser.doProcessSimple(scan)) {
 
         auto scan_msg = std::make_shared<sensor_msgs::msg::LaserScan>();

--- a/src/ydlidar_ros2_driver_node.cpp
+++ b/src/ydlidar_ros2_driver_node.cpp
@@ -190,37 +190,39 @@ int main(int argc, char *argv[]) {
 
     LaserScan scan;//
 
-    if (laser.doProcessSimple(scan)) {
+    if (laser.isScanning){
+      if (laser.doProcessSimple(scan)) {
 
-      auto scan_msg = std::make_shared<sensor_msgs::msg::LaserScan>();
+        auto scan_msg = std::make_shared<sensor_msgs::msg::LaserScan>();
 
-      scan_msg->header.stamp.sec = RCL_NS_TO_S(scan.stamp);
-      scan_msg->header.stamp.nanosec =  scan.stamp - RCL_S_TO_NS(scan_msg->header.stamp.sec);
-      scan_msg->header.frame_id = frame_id;
-      scan_msg->angle_min = scan.config.min_angle;
-      scan_msg->angle_max = scan.config.max_angle;
-      scan_msg->angle_increment = scan.config.angle_increment;
-      scan_msg->scan_time = scan.config.scan_time;
-      scan_msg->time_increment = scan.config.time_increment;
-      scan_msg->range_min = scan.config.min_range;
-      scan_msg->range_max = scan.config.max_range;
-      
-      int size = (scan.config.max_angle - scan.config.min_angle)/ scan.config.angle_increment + 1;
-      scan_msg->ranges.resize(size);
-      scan_msg->intensities.resize(size);
-      for(size_t i=0; i < scan.points.size(); i++) {
-        int index = std::ceil((scan.points[i].angle - scan.config.min_angle)/scan.config.angle_increment);
-        if(index >=0 && index < size) {
-          scan_msg->ranges[index] = scan.points[i].range;
-          scan_msg->intensities[index] = scan.points[i].intensity;
+        scan_msg->header.stamp.sec = RCL_NS_TO_S(scan.stamp);
+        scan_msg->header.stamp.nanosec =  scan.stamp - RCL_S_TO_NS(scan_msg->header.stamp.sec);
+        scan_msg->header.frame_id = frame_id;
+        scan_msg->angle_min = scan.config.min_angle;
+        scan_msg->angle_max = scan.config.max_angle;
+        scan_msg->angle_increment = scan.config.angle_increment;
+        scan_msg->scan_time = scan.config.scan_time;
+        scan_msg->time_increment = scan.config.time_increment;
+        scan_msg->range_min = scan.config.min_range;
+        scan_msg->range_max = scan.config.max_range;
+        
+        int size = (scan.config.max_angle - scan.config.min_angle)/ scan.config.angle_increment + 1;
+        scan_msg->ranges.resize(size);
+        scan_msg->intensities.resize(size);
+        for(size_t i=0; i < scan.points.size(); i++) {
+          int index = std::ceil((scan.points[i].angle - scan.config.min_angle)/scan.config.angle_increment);
+          if(index >=0 && index < size) {
+            scan_msg->ranges[index] = scan.points[i].range;
+            scan_msg->intensities[index] = scan.points[i].intensity;
+          }
         }
+
+        laser_pub->publish(*scan_msg);
+
+
+      } else {
+        RCLCPP_ERROR(node->get_logger(), "Failed to get scan");
       }
-
-      laser_pub->publish(*scan_msg);
-
-
-    } else {
-      RCLCPP_ERROR(node->get_logger(), "Failed to get scan");
     }
     if(!rclcpp::ok()) {
       break;


### PR DESCRIPTION
I have seen a bug with the service stop scan.

I you call it, the node will flood you with error because the scan are not available.
But this is normal because you asked it to stop sending the scan.

Fortunately enough there is a function called laser.isScanning() so I added it.

Unfortunately when because of reformatting the code it looks like I changed a lot of stuff in the end. it is really just one line
See line 193 and closing the bracket again ..
