### PR TITLE
A workaround for SLAM-Toolbox, fixed scan data size output mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,8 @@ NOTE: But if the message like this still occurs and very few data use by the `sl
 ```
 This means that slam_toolbox captured the scan data at the wrong time, **restart slam_toolbox to solve the problem**.  
   
-The `slam_toolbox` seems to capture only one of the data in the vary first time as the basis of data size validation, and will be calculated by the formula `max_angle - min_angle / angle_increment + residual` (`residual` in 360 degrees Lidar is `0`, others lidar is `1`), if the data size calculated from the `angle_increment` value happens to be different from the one calculated in this node, it will lead to the problem that most of the data can not be verified.  
+The `slam_toolbox` seems to capture only one of the data in the vary first time as the basis of data size validation, and will be calculated by the formula `max_angle - min_angle / angle_increment + residual` (`residual` in 360 degrees Lidar is `0`, others lidar is `1`), if the data size calculated from the `angle_increment` value to be different from the provided by this node, it will cause the problem that the data can not be verified.  
+(Seems like some lidar's rotation speed not stable, so cause the unstable data count of each rotation).  
 
 ## Contact EAI
 ![Development Path](images/EAI.png)

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ ydlidar_ros2_driver_node:
     frequency: 10.0
     invalid_range_is_inf: false
     debug: false
+    fixed_scan_size: true
 ```
 Note: It needs to be modified according to LiDAR actual situation.
 
@@ -169,7 +170,7 @@ The ydlidar_ros2_driver internal parameters are in the launch file, they are lis
 | sample_rate     | int | Set Lidar Sample Rate. <br/>default: `9` |
 | abnormal_check_count     | int | Set the number of abnormal startup data attempts. <br/>default: `4` |
 | fixed_resolution     | bool | Fixed angluar resolution. <br/>default: `true` |
-| reversion     | bool | Reversion LiDAR. <br/>default: `true` |
+| reversion     | bool | Reversion LiDAR. (Lidar's data rotate 180 deg) <br/>default: `true` |
 | inverted     | bool | Inverted LiDAR.<br/>false -- ClockWise.<br/>true -- CounterClockWise  <br/>default: `true` |
 | auto_reconnect     | bool | Automatically reconnect the LiDAR.<br/>true -- hot plug. <br/>default: `true` |
 | isSingleChannel     | bool | Whether LiDAR is a single-channel.<br/>default: `false` |
@@ -181,7 +182,22 @@ The ydlidar_ros2_driver internal parameters are in the launch file, they are lis
 | range_max     | float | Maximum Valid range.<br/>default: `16.0` |
 | frequency     | float | Set Scanning Frequency.<br/>default: `10.0` |
 | invalid_range_is_inf     | bool | Invalid Range is inf.<br/>true -- inf.<br/>false -- 0.0.<br/>default: `false` |
+| fixed_scan_size     | bool | Outputs a fixed scan data size.<br/>default: `true` |
 More paramters details, see [here](details.md)
+
+## Notes about `fixed_scan_size`
+This function will outputs fixed size of scan data, data that is over or under is truncated or filled up, the data size depends on the average of the first 30 scans obtained after the node is activated, which for `slam_toolbox` reduces the chance of data being discarded.  
+  
+NOTE: But if the message like this still occurs and very few data use by the `slam_toolbox`:  
+```
+[async_slam_toolbox_node-9] LaserRangeScan contains 602 range readings, expected 600
+[async_slam_toolbox_node-9] LaserRangeScan contains 602 range readings, expected 600
+[async_slam_toolbox_node-9] LaserRangeScan contains 602 range readings, expected 600
+...
+```
+This means that slam_toolbox captured the scan data at the wrong time, **restart slam_toolbox to solve the problem**.  
+  
+The `slam_toolbox` seems to capture only one of the data in the vary first time as the basis of data size validation, and will be calculated by the formula `max_angle - min_angle / angle_increment + residual` (`residual` in 360 degrees Lidar is `0`, others lidar is `1`), if the data size calculated from the `angle_increment` value happens to be different from the one calculated in this node, it will lead to the problem that most of the data can not be verified, the purpose of adopting the average value in this node is to reduce the chance that the calculated value is different from the value captured by `slam_toolbox`.
 
 ## Contact EAI
 ![Development Path](images/EAI.png)

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ The ydlidar_ros2_driver internal parameters are in the launch file, they are lis
 More paramters details, see [here](details.md)
 
 ## Notes about `fixed_scan_size`
-This function will outputs fixed size of scan data, data that is over or under is truncated or filled up, the data size depends on the average of the first 30 scans obtained after the node is activated, which for `slam_toolbox` reduces the chance of data being discarded.  
+This function will outputs fixed size of scan data, data that is over or under is truncated or filled up, the data size depends on the mode of the first 30 scans's data size after the node is activated, which for `slam_toolbox` to prevent the chance of data being discarded.  
   
 NOTE: But if the message like this still occurs and very few data use by the `slam_toolbox`:  
 ```
@@ -197,7 +197,7 @@ NOTE: But if the message like this still occurs and very few data use by the `sl
 ```
 This means that slam_toolbox captured the scan data at the wrong time, **restart slam_toolbox to solve the problem**.  
   
-The `slam_toolbox` seems to capture only one of the data in the vary first time as the basis of data size validation, and will be calculated by the formula `max_angle - min_angle / angle_increment + residual` (`residual` in 360 degrees Lidar is `0`, others lidar is `1`), if the data size calculated from the `angle_increment` value happens to be different from the one calculated in this node, it will lead to the problem that most of the data can not be verified, the purpose of adopting the average value in this node is to reduce the chance that the calculated value is different from the value captured by `slam_toolbox`.
+The `slam_toolbox` seems to capture only one of the data in the vary first time as the basis of data size validation, and will be calculated by the formula `max_angle - min_angle / angle_increment + residual` (`residual` in 360 degrees Lidar is `0`, others lidar is `1`), if the data size calculated from the `angle_increment` value happens to be different from the one calculated in this node, it will lead to the problem that most of the data can not be verified.  
 
 ## Contact EAI
 ![Development Path](images/EAI.png)

--- a/README.md
+++ b/README.md
@@ -186,16 +186,18 @@ The ydlidar_ros2_driver internal parameters are in the launch file, they are lis
 More paramters details, see [here](details.md)
 
 ## Notes about `fixed_scan_size`
-This function will outputs fixed size of scan data, data that is over or under is truncated or filled up, the data size depends on the mode of the first 30 scans's data size after the node is activated, which for `slam_toolbox` to prevent the chance of data being discarded.  
+This function will outputs fixed size of scan data, it will put the nearest sample points to the fix-sized slots, the data size and angle increasement depends on the mode of the first 30 scans's data size after the node is activated, which for `slam_toolbox` to prevent the chance of data being discarded.  
   
-NOTE: But if the message like this still occurs and very few data use by the `slam_toolbox`:  
+~~NOTE: But if the message like this still occurs and very few data use by the `slam_toolbox`:~~  
 ```
 [async_slam_toolbox_node-9] LaserRangeScan contains 602 range readings, expected 600
 [async_slam_toolbox_node-9] LaserRangeScan contains 602 range readings, expected 600
 [async_slam_toolbox_node-9] LaserRangeScan contains 602 range readings, expected 600
 ...
 ```
-This means that slam_toolbox captured the scan data at the wrong time, **restart slam_toolbox to solve the problem**.  
+~~This means that slam_toolbox captured the scan data at the wrong time, **restart slam_toolbox to solve the problem**.~~  
+  
+2025/06/10 Changelog: Change the function to fix the `angle_increment` and the `scan_size`, then find the nearest sample point from lidar to put in, so the problem may not occur again! 
   
 The `slam_toolbox` seems to capture only one of the data in the vary first time as the basis of data size validation, and will be calculated by the formula `max_angle - min_angle / angle_increment + residual` (`residual` in 360 degrees Lidar is `0`, others lidar is `1`), if the data size calculated from the `angle_increment` value to be different from the provided by this node, it will cause the problem that the data can not be verified.  
 (Seems like some lidar's rotation speed not stable, so cause the unstable data count of each rotation).  

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ The ydlidar_ros2_driver internal parameters are in the launch file, they are lis
 | range_max     | float | Maximum Valid range.<br/>default: `16.0` |
 | frequency     | float | Set Scanning Frequency.<br/>default: `10.0` |
 | invalid_range_is_inf     | bool | Invalid Range is inf.<br/>true -- inf.<br/>false -- 0.0.<br/>default: `false` |
-| fixed_scan_size     | bool | Outputs a fixed scan data size.<br/>default: `true` |
+| fixed_scan_size     | bool | Outputs fixed scan data size, workaround for `slam_toolbox`.<br/>default: `true` |
 More paramters details, see [here](details.md)
 
 ## Notes about `fixed_scan_size`

--- a/src/ydlidar_ros2_driver_node.cpp
+++ b/src/ydlidar_ros2_driver_node.cpp
@@ -31,20 +31,22 @@
 
 #define ROS2Verision "1.0.1"
 
-// Function to findout mode to guess the validation value use by slam_toolbox
+// Function to findout mode to guess the validation value use by slam_toolbox.
 int findMode(int data[], int size) {
     int maxCount = 0;
     int mode = data[0];
-
+    // Loop for check all values in the array.
     for (int i = 0; i < size; i++) {
         int count = 0;
-
+        // Loop for compare is it a value in array same as "the value to be check"(Outer loop).
         for (int j = 0; j < size; j++) {
             if (data[j] == data[i]) {
+                // If value are the same, add the counter.
                 count++;
             }
         }
-
+        // If the final counter value is largest, update the maxCount, and make this value in array
+        // as the temporary mode number, until the final mode value to be find.
         if (count > maxCount) {
             maxCount = count;
             mode = data[i];

--- a/src/ydlidar_ros2_driver_node.cpp
+++ b/src/ydlidar_ros2_driver_node.cpp
@@ -32,9 +32,9 @@
 #define ROS2Verision "1.0.1"
 
 // Function to findout mode to guess the validation value use by slam_toolbox.
-int findMode(int data[], int size) {
+void findMode(int data[], int size, int* mode_value, int* mode_index) {
     int maxCount = 0;
-    int mode = data[0];
+    *mode_value = data[0];
     // Loop for check all values in the array.
     for (int i = 0; i < size; i++) {
         int count = 0;
@@ -49,11 +49,10 @@ int findMode(int data[], int size) {
         // as the temporary mode number, until the final mode value to be find.
         if (count > maxCount) {
             maxCount = count;
-            mode = data[i];
+            *mode_value = data[i];
+            *mode_index = i;
         }
     }
-
-    return mode;
 }
 
 int main(int argc, char *argv[])
@@ -246,7 +245,9 @@ int main(int argc, char *argv[])
 
   int scan_size_cal_count = 0;
   int fixed_scan_size = 0;
+  float fixed_angle_inc = 0.0f;
   int a_scan_size[30] = {0};
+  float a_scan_ang_inc[30] = {0.0f};
 
   while (ret && rclcpp::ok())
   {
@@ -261,6 +262,7 @@ int main(int argc, char *argv[])
         if (scan_size_cal_count == 0)
           RCLCPP_INFO(node->get_logger(), "[YDLIDAR INFO] Calculate the fixed scan size by first 30 data, please wait...");
         a_scan_size[scan_size_cal_count] = scan.points.size();
+        a_scan_ang_inc[scan_size_cal_count] = scan.config.angle_increment;
         scan_size_cal_count++;
       }
       else
@@ -271,8 +273,10 @@ int main(int argc, char *argv[])
           // slam_toolbox's vaildate function: max_angle - min_angle / angle_increment + residual
           // (residual = 0 if it is 360 deg lidar, others is 1)
           // (The vaildation value seems like just calculate at first time)
-          fixed_scan_size = findMode(a_scan_size, 30);
-          RCLCPP_INFO(node->get_logger(), "[YDLIDAR INFO] Fixed scan size = %d", fixed_scan_size);
+          int mode_index = 0;
+          findMode(a_scan_size, 30, &fixed_scan_size, &mode_index);
+          fixed_angle_inc = a_scan_ang_inc[mode_index];
+          RCLCPP_INFO(node->get_logger(), "[YDLIDAR INFO] Fixed scan size = %d, angle inc. = %f", fixed_scan_size, fixed_angle_inc);
           scan_size_cal_count++;
         }
         auto scan_msg = std::make_shared<sensor_msgs::msg::LaserScan>();
@@ -284,7 +288,17 @@ int main(int argc, char *argv[])
         pc_msg->header = scan_msg->header;
         scan_msg->angle_min = scan.config.min_angle;
         scan_msg->angle_max = scan.config.max_angle;
-        scan_msg->angle_increment = scan.config.angle_increment;
+        if (b_fixed_scan_size)
+        {
+          // We also replace the original `scan.config.angle_increment` to let the functions later can calculate
+          // the nearst slot to put the scan value in (The lidar will return the point's distance and angle)
+          scan_msg->angle_increment = fixed_angle_inc;
+          scan.config.angle_increment = fixed_angle_inc;
+        }
+        else
+        {
+          scan_msg->angle_increment = scan.config.angle_increment;
+        }
         scan_msg->scan_time = scan.config.scan_time;
         scan_msg->time_increment = scan.config.time_increment;
         scan_msg->range_min = scan.config.min_range;
@@ -312,7 +326,9 @@ int main(int argc, char *argv[])
 
         for (size_t i = 0; i < scan.points.size(); i++)
         {
-          int index = std::ceil((scan.points[i].angle - scan.config.min_angle) / scan.config.angle_increment);
+          // Calculate the nearest array index for the current point based on its angle.
+          // Note: change the celi to round to approach the nearst slot!
+          int index = std::round((scan.points[i].angle - scan.config.min_angle) / scan.config.angle_increment);
           if (index >= 0 && index < size)
           {
             // Fixed: add the logic that value larger than the max_range is invalid

--- a/src/ydlidar_ros2_driver_node.cpp
+++ b/src/ydlidar_ros2_driver_node.cpp
@@ -148,7 +148,7 @@ int main(int argc, char *argv[])
   node->get_parameter("support_motor_dtr", b_optvalue);
   laser.setlidaropt(LidarPropSupportMotorDtrCtrl, &b_optvalue, sizeof(bool));
   // Fixed scan size
-  bool b_fixed_scan_size = false;
+  bool b_fixed_scan_size = true;
   node->declare_parameter("fixed_scan_size", b_fixed_scan_size);
   node->get_parameter("fixed_scan_size", b_fixed_scan_size);
   // Enable Debug

--- a/src/ydlidar_ros2_driver_node.cpp
+++ b/src/ydlidar_ros2_driver_node.cpp
@@ -273,7 +273,7 @@ int main(int argc, char *argv[])
           // (The vaildation value seems like just calculate at first time)
           int mode_index = 0;
           findMode(a_scan_size, 30, &fixed_scan_size, &mode_index);
-          // Update angle_increment also calculated here, the lidar like TG30 not returns the correct angle increasement!
+          // Update 250611: angle_increment also calculated here, the lidar like TG30 not returns the correct angle increasement!
           int scan_size_cal = fixed_scan_size;
           // If you got the expected smaller 1 than the actual size, comment out!
           if ( f_maxangle != 180.0f || f_minangle != -180.0f ) scan_size_cal--;

--- a/src/ydlidar_ros2_driver_node.cpp
+++ b/src/ydlidar_ros2_driver_node.cpp
@@ -31,8 +31,8 @@
 
 #define ROS2Verision "1.0.1"
 
-
-int main(int argc, char *argv[]) {
+int main(int argc, char *argv[])
+{
   rclcpp::init(argc, argv);
 
   auto node = rclcpp::Node::make_shared("ydlidar_ros2_driver_node");
@@ -43,10 +43,10 @@ int main(int argc, char *argv[]) {
   std::string str_optvalue = "/dev/ydlidar";
   node->declare_parameter("port", str_optvalue);
   node->get_parameter("port", str_optvalue);
-  ///lidar port
+  /// lidar port
   laser.setlidaropt(LidarPropSerialPort, str_optvalue.c_str(), str_optvalue.size());
 
-  ///ignore array
+  /// ignore array
   str_optvalue = "";
   node->declare_parameter("ignore_array", str_optvalue);
   node->get_parameter("ignore_array", str_optvalue);
@@ -88,7 +88,7 @@ int main(int argc, char *argv[]) {
   node->declare_parameter("intensity_bit", optval);
   node->get_parameter("intensity_bit", optval);
   laser.setlidaropt(LidarPropIntenstiyBit, &optval, sizeof(int));
-     
+
   //////////////////////bool property/////////////////
   /// fixed angle resolution
   bool b_optvalue = false;
@@ -124,7 +124,11 @@ int main(int argc, char *argv[]) {
   node->declare_parameter("support_motor_dtr", b_optvalue);
   node->get_parameter("support_motor_dtr", b_optvalue);
   laser.setlidaropt(LidarPropSupportMotorDtrCtrl, &b_optvalue, sizeof(bool));
-  //是否启用调试
+  // Fixed scan size
+  bool b_fixed_scan_size = false;
+  node->declare_parameter("fixed_scan_size", b_fixed_scan_size);
+  node->get_parameter("fixed_scan_size", b_fixed_scan_size);
+  // Enable Debug
   b_optvalue = false;
   node->declare_parameter("debug", b_optvalue);
   node->get_parameter("debug", b_optvalue);
@@ -132,16 +136,16 @@ int main(int argc, char *argv[]) {
 
   //////////////////////float property/////////////////
   /// unit: °
-  float f_optvalue = 180.0f;
-  node->declare_parameter("angle_max", f_optvalue);
-  node->get_parameter("angle_max", f_optvalue);
-  laser.setlidaropt(LidarPropMaxAngle, &f_optvalue, sizeof(float));
-  f_optvalue = -180.0f;
-  node->declare_parameter("angle_min", f_optvalue);
-  node->get_parameter("angle_min", f_optvalue);
-  laser.setlidaropt(LidarPropMinAngle, &f_optvalue, sizeof(float));
+  float f_maxangle = 180.0f;
+  node->declare_parameter("angle_max", f_maxangle);
+  node->get_parameter("angle_max", f_maxangle);
+  laser.setlidaropt(LidarPropMaxAngle, &f_maxangle, sizeof(float));
+  float f_minangle = -180.0f;
+  node->declare_parameter("angle_min", f_minangle);
+  node->get_parameter("angle_min", f_minangle);
+  laser.setlidaropt(LidarPropMinAngle, &f_minangle, sizeof(float));
   /// unit: m
-  f_optvalue = 64.f;
+  float f_optvalue = 64.f;
   node->declare_parameter("range_max", f_optvalue);
   node->get_parameter("range_max", f_optvalue);
   laser.setlidaropt(LidarPropMaxRange, &f_optvalue, sizeof(float));
@@ -159,11 +163,10 @@ int main(int argc, char *argv[]) {
   node->declare_parameter("invalid_range_is_inf", invalid_range_is_inf);
   node->get_parameter("invalid_range_is_inf", invalid_range_is_inf);
 
-
   bool ret = laser.initialize();
-  if (ret) 
+  if (ret)
   {
-    //设置GS工作模式（非GS雷达请无视该代码）
+    // 设置GS工作模式（非GS雷达请无视该代码）
     int i_v = 0;
     node->declare_parameter("m1_mode", i_v);
     node->get_parameter("m1_mode", i_v);
@@ -176,105 +179,150 @@ int main(int argc, char *argv[]) {
     node->declare_parameter("m3_mode", i_v);
     node->get_parameter("m3_mode", i_v);
     laser.setWorkMode(i_v, 0x04);
-    //启动扫描
+    // 启动扫描
     ret = laser.turnOn();
-  } 
-  else 
+  }
+  else
   {
     RCLCPP_ERROR(node->get_logger(), "%s\n", laser.DescribeError());
   }
-  
+
   auto laser_pub = node->create_publisher<sensor_msgs::msg::LaserScan>("scan", rclcpp::SensorDataQoS());
   auto pc_pub = node->create_publisher<sensor_msgs::msg::PointCloud>("point_cloud", rclcpp::SensorDataQoS());
-  
+
   auto stop_scan_service =
-    [&laser](const std::shared_ptr<rmw_request_id_t> request_header,
-  const std::shared_ptr<std_srvs::srv::Empty::Request> req,
-  std::shared_ptr<std_srvs::srv::Empty::Response> response) -> bool
+      [&laser](const std::shared_ptr<rmw_request_id_t> request_header,
+               const std::shared_ptr<std_srvs::srv::Empty::Request> req,
+               std::shared_ptr<std_srvs::srv::Empty::Response> response) -> bool
   {
     return laser.turnOff();
   };
 
-  auto stop_service = node->create_service<std_srvs::srv::Empty>("stop_scan",stop_scan_service);
+  auto stop_service = node->create_service<std_srvs::srv::Empty>("stop_scan", stop_scan_service);
 
   auto start_scan_service =
-    [&laser](const std::shared_ptr<rmw_request_id_t> request_header,
-  const std::shared_ptr<std_srvs::srv::Empty::Request> req,
-  std::shared_ptr<std_srvs::srv::Empty::Response> response) -> bool
+      [&laser](const std::shared_ptr<rmw_request_id_t> request_header,
+               const std::shared_ptr<std_srvs::srv::Empty::Request> req,
+               std::shared_ptr<std_srvs::srv::Empty::Response> response) -> bool
   {
     return laser.turnOn();
   };
 
-  auto start_service = node->create_service<std_srvs::srv::Empty>("start_scan",start_scan_service);
+  auto start_service = node->create_service<std_srvs::srv::Empty>("start_scan", start_scan_service);
 
   rclcpp::WallRate loop_rate(20);
 
-  while (ret && rclcpp::ok()) {
+  int scan_size_cal_count = 0;
+  int fixed_scan_size = 0;
+  float sum_angle_increment = 0.0f;
 
-    LaserScan scan;//
+  while (ret && rclcpp::ok())
+  {
 
-    if (laser.doProcessSimple(scan)) {
+    LaserScan scan; //
 
-      auto scan_msg = std::make_shared<sensor_msgs::msg::LaserScan>();
-      auto pc_msg = std::make_shared<sensor_msgs::msg::PointCloud>();
-
-      scan_msg->header.stamp.sec = RCL_NS_TO_S(scan.stamp);
-      scan_msg->header.stamp.nanosec =  scan.stamp - RCL_S_TO_NS(scan_msg->header.stamp.sec);
-      scan_msg->header.frame_id = frame_id;
-      pc_msg->header = scan_msg->header;
-      scan_msg->angle_min = scan.config.min_angle;
-      scan_msg->angle_max = scan.config.max_angle;
-      scan_msg->angle_increment = scan.config.angle_increment;
-      scan_msg->scan_time = scan.config.scan_time;
-      scan_msg->time_increment = scan.config.time_increment;
-      scan_msg->range_min = scan.config.min_range;
-      scan_msg->range_max = scan.config.max_range;
-      
-      int size = (scan.config.max_angle - scan.config.min_angle)/ scan.config.angle_increment + 1;
-      scan_msg->ranges.resize(size);
-      scan_msg->intensities.resize(size);
-
-      pc_msg->channels.resize(2);
-      int idx_intensity = 0;
-      pc_msg->channels[idx_intensity].name = "intensities";
-      int idx_timestamp = 1;
-      pc_msg->channels[idx_timestamp].name = "stamps";
-
-      for(size_t i=0; i < scan.points.size(); i++) {
-        int index = std::ceil((scan.points[i].angle - scan.config.min_angle)/scan.config.angle_increment);
-        if(index >=0 && index < size) {
-	  if (scan.points[i].range >= scan.config.min_range) {
-            scan_msg->ranges[index] = scan.points[i].range;
-            scan_msg->intensities[index] = scan.points[i].intensity;
-	  }
-        }
-
-	if (scan.points[i].range >= scan.config.min_range &&
-             scan.points[i].range <= scan.config.max_range) {
-          geometry_msgs::msg::Point32 point;
-          point.x = scan.points[i].range * cos(scan.points[i].angle);
-          point.y = scan.points[i].range * sin(scan.points[i].angle);
-          point.z = 0.0;
-          pc_msg->points.push_back(point);
-          pc_msg->channels[idx_intensity].values.push_back(scan.points[i].intensity);
-          pc_msg->channels[idx_timestamp].values.push_back(i * scan.config.time_increment);
-        }
-
+    if (laser.doProcessSimple(scan))
+    {
+      if (b_fixed_scan_size && scan_size_cal_count < 30)
+      {
+        // Sum first 30 scan's angle_increment
+        if (scan_size_cal_count == 0)
+          RCLCPP_INFO(node->get_logger(), "[YDLIDAR INFO] Calculate the fixed scan size by first 30 data, please wait...");
+        sum_angle_increment += scan.config.angle_increment;
+        scan_size_cal_count++;
       }
+      else
+      {
+        if (scan_size_cal_count == 30)
+        {
+          // Calculate the average of the first 30 scan's angle_increment, and get the best fixed scan size
+          // The fixed size of the LaserScan data
+          // slam_toolbox's vaildate function: max_angle - min_angle / angle_increment + residual
+          // (residual = 0 if it is 360 deg lidar, others is 1)
+          // (The vaildation value seems like just calculate at first time)
+          fixed_scan_size = (scan.config.max_angle - scan.config.min_angle) / (sum_angle_increment / 30);
+          RCLCPP_INFO(node->get_logger(), "[YDLIDAR INFO] Fixed scan size = %d", fixed_scan_size);
+          RCLCPP_INFO(node->get_logger(), "[YDLIDAR INFO] Max angle: %f", scan.config.max_angle);
+          if (!(f_maxangle == 180.0f && f_minangle == -180.0f)) fixed_scan_size++;
+          scan_size_cal_count++;
+        }
+        auto scan_msg = std::make_shared<sensor_msgs::msg::LaserScan>();
+        auto pc_msg = std::make_shared<sensor_msgs::msg::PointCloud>();
 
-      laser_pub->publish(*scan_msg);
-      pc_pub->publish(*pc_msg);
+        scan_msg->header.stamp.sec = RCL_NS_TO_S(scan.stamp);
+        scan_msg->header.stamp.nanosec = scan.stamp - RCL_S_TO_NS(scan_msg->header.stamp.sec);
+        scan_msg->header.frame_id = frame_id;
+        pc_msg->header = scan_msg->header;
+        scan_msg->angle_min = scan.config.min_angle;
+        scan_msg->angle_max = scan.config.max_angle;
+        scan_msg->angle_increment = scan.config.angle_increment;
+        scan_msg->scan_time = scan.config.scan_time;
+        scan_msg->time_increment = scan.config.time_increment;
+        scan_msg->range_min = scan.config.min_range;
+        scan_msg->range_max = scan.config.max_range;
 
-    } else {
+        // Let the LaserScan's topic size fixed when fixed_scan_size is true, keep the original logic if is false
+        int size = 0;
+        if (b_fixed_scan_size)
+        {
+          size = fixed_scan_size;
+        }
+        else
+        {
+          size = (scan.config.max_angle - scan.config.min_angle) / scan.config.angle_increment + 1;
+        }
+
+        scan_msg->ranges.resize(size);
+        scan_msg->intensities.resize(size);
+
+        pc_msg->channels.resize(2);
+        int idx_intensity = 0;
+        pc_msg->channels[idx_intensity].name = "intensities";
+        int idx_timestamp = 1;
+        pc_msg->channels[idx_timestamp].name = "stamps";
+
+        for (size_t i = 0; i < scan.points.size(); i++)
+        {
+          int index = std::ceil((scan.points[i].angle - scan.config.min_angle) / scan.config.angle_increment);
+          if (index >= 0 && index < size)
+          {
+            // Fixed: add the logic that value larger than the max_range is invalid
+            if (scan.points[i].range >= scan.config.min_range &&
+                scan.points[i].range <= scan.config.max_range)
+            {
+              scan_msg->ranges[index] = scan.points[i].range;
+              scan_msg->intensities[index] = scan.points[i].intensity;
+            }
+          }
+
+          if (scan.points[i].range >= scan.config.min_range &&
+              scan.points[i].range <= scan.config.max_range)
+          {
+            geometry_msgs::msg::Point32 point;
+            point.x = scan.points[i].range * cos(scan.points[i].angle);
+            point.y = scan.points[i].range * sin(scan.points[i].angle);
+            point.z = 0.0;
+            pc_msg->points.push_back(point);
+            pc_msg->channels[idx_intensity].values.push_back(scan.points[i].intensity);
+            pc_msg->channels[idx_timestamp].values.push_back(i * scan.config.time_increment);
+          }
+        }
+
+        laser_pub->publish(*scan_msg);
+        pc_pub->publish(*pc_msg);
+      }
+    }
+    else
+    {
       RCLCPP_ERROR(node->get_logger(), "Failed to get scan");
     }
-    if(!rclcpp::ok()) {
+    if (!rclcpp::ok())
+    {
       break;
     }
     rclcpp::spin_some(node);
     loop_rate.sleep();
   }
-
 
   RCLCPP_INFO(node->get_logger(), "[YDLIDAR INFO] Now YDLIDAR is stopping .......");
   laser.turnOff();

--- a/src/ydlidar_ros2_driver_node.cpp
+++ b/src/ydlidar_ros2_driver_node.cpp
@@ -31,6 +31,29 @@
 
 #define ROS2Verision "1.0.1"
 
+// Function to findout mode to guess the validation value use by slam_toolbox
+int findMode(int data[], int size) {
+    int maxCount = 0;
+    int mode = data[0];
+
+    for (int i = 0; i < size; i++) {
+        int count = 0;
+
+        for (int j = 0; j < size; j++) {
+            if (data[j] == data[i]) {
+                count++;
+            }
+        }
+
+        if (count > maxCount) {
+            maxCount = count;
+            mode = data[i];
+        }
+    }
+
+    return mode;
+}
+
 int main(int argc, char *argv[])
 {
   rclcpp::init(argc, argv);
@@ -221,7 +244,7 @@ int main(int argc, char *argv[])
 
   int scan_size_cal_count = 0;
   int fixed_scan_size = 0;
-  float sum_angle_increment = 0.0f;
+  int a_scan_size[30] = {0};
 
   while (ret && rclcpp::ok())
   {
@@ -235,21 +258,19 @@ int main(int argc, char *argv[])
         // Sum first 30 scan's angle_increment
         if (scan_size_cal_count == 0)
           RCLCPP_INFO(node->get_logger(), "[YDLIDAR INFO] Calculate the fixed scan size by first 30 data, please wait...");
-        sum_angle_increment += scan.config.angle_increment;
+        a_scan_size[scan_size_cal_count] = scan.points.size();
         scan_size_cal_count++;
       }
       else
       {
         if (scan_size_cal_count == 30)
         {
-          // Calculate the average of the first 30 scan's angle_increment, and get the best fixed scan size
-          // The fixed size of the LaserScan data
+          // Calculate the mode of the first 30 scan's scan data size.
           // slam_toolbox's vaildate function: max_angle - min_angle / angle_increment + residual
           // (residual = 0 if it is 360 deg lidar, others is 1)
           // (The vaildation value seems like just calculate at first time)
-          fixed_scan_size = (scan.config.max_angle - scan.config.min_angle) / (sum_angle_increment / 30);
+          fixed_scan_size = findMode(a_scan_size, 30);
           RCLCPP_INFO(node->get_logger(), "[YDLIDAR INFO] Fixed scan size = %d", fixed_scan_size);
-          if (!(f_maxangle == 180.0f && f_minangle == -180.0f)) fixed_scan_size++;
           scan_size_cal_count++;
         }
         auto scan_msg = std::make_shared<sensor_msgs::msg::LaserScan>();

--- a/src/ydlidar_ros2_driver_node.cpp
+++ b/src/ydlidar_ros2_driver_node.cpp
@@ -247,7 +247,6 @@ int main(int argc, char *argv[])
   int fixed_scan_size = 0;
   float fixed_angle_inc = 0.0f;
   int a_scan_size[30] = {0};
-  float a_scan_ang_inc[30] = {0.0f};
 
   while (ret && rclcpp::ok())
   {
@@ -262,7 +261,6 @@ int main(int argc, char *argv[])
         if (scan_size_cal_count == 0)
           RCLCPP_INFO(node->get_logger(), "[YDLIDAR INFO] Calculate the fixed scan size by first 30 data, please wait...");
         a_scan_size[scan_size_cal_count] = scan.points.size();
-        a_scan_ang_inc[scan_size_cal_count] = scan.config.angle_increment;
         scan_size_cal_count++;
       }
       else
@@ -275,7 +273,11 @@ int main(int argc, char *argv[])
           // (The vaildation value seems like just calculate at first time)
           int mode_index = 0;
           findMode(a_scan_size, 30, &fixed_scan_size, &mode_index);
-          fixed_angle_inc = a_scan_ang_inc[mode_index];
+          // Update angle_increment also calculated here, the lidar like TG30 not returns the correct angle increasement!
+          int scan_size_cal = fixed_scan_size;
+          // If you got the expected smaller 1 than the actual size, comment out!
+          if ( f_maxangle != 180.0f || f_minangle != -180.0f ) scan_size_cal--;
+          fixed_angle_inc = (scan.config.max_angle - scan.config.min_angle) / scan_size_cal;
           RCLCPP_INFO(node->get_logger(), "[YDLIDAR INFO] Fixed scan size = %d, angle inc. = %f", fixed_scan_size, fixed_angle_inc);
           scan_size_cal_count++;
         }

--- a/src/ydlidar_ros2_driver_node.cpp
+++ b/src/ydlidar_ros2_driver_node.cpp
@@ -163,6 +163,12 @@ int main(int argc, char *argv[])
   node->declare_parameter("invalid_range_is_inf", invalid_range_is_inf);
   node->get_parameter("invalid_range_is_inf", invalid_range_is_inf);
 
+  // Publisher for LaserScan with updated QoS settings
+  // Refrence by Oyefusi-Samuel's workaround: https://github.com/Oyefusi-Samuel/ydlidar_ros2_driver-master
+  rclcpp::QoS qos(rclcpp::KeepLast(10));  // Keep last 10 messages in the buffer
+  qos.reliable();  // Ensure reliable delivery of messages
+  qos.durability_volatile();  // Volatile durability, meaning no retention of messages after disconnect
+
   bool ret = laser.initialize();
   if (ret)
   {
@@ -187,8 +193,9 @@ int main(int argc, char *argv[])
     RCLCPP_ERROR(node->get_logger(), "%s\n", laser.DescribeError());
   }
 
-  auto laser_pub = node->create_publisher<sensor_msgs::msg::LaserScan>("scan", rclcpp::SensorDataQoS());
-  auto pc_pub = node->create_publisher<sensor_msgs::msg::PointCloud>("point_cloud", rclcpp::SensorDataQoS());
+  // Apply our QoS policy
+  auto laser_pub = node->create_publisher<sensor_msgs::msg::LaserScan>("scan", qos);
+  auto pc_pub = node->create_publisher<sensor_msgs::msg::PointCloud>("point_cloud", qos);
 
   auto stop_scan_service =
       [&laser](const std::shared_ptr<rmw_request_id_t> request_header,
@@ -242,7 +249,6 @@ int main(int argc, char *argv[])
           // (The vaildation value seems like just calculate at first time)
           fixed_scan_size = (scan.config.max_angle - scan.config.min_angle) / (sum_angle_increment / 30);
           RCLCPP_INFO(node->get_logger(), "[YDLIDAR INFO] Fixed scan size = %d", fixed_scan_size);
-          RCLCPP_INFO(node->get_logger(), "[YDLIDAR INFO] Max angle: %f", scan.config.max_angle);
           if (!(f_maxangle == 180.0f && f_minangle == -180.0f)) fixed_scan_size++;
           scan_size_cal_count++;
         }


### PR DESCRIPTION
This pull request provides a workaround for the problem like following:
https://github.com/SteveMacenski/slam_toolbox/issues/63
  
Add the parameter `fixed_scan_size` to limit `scan_size` and `angle_increasement` to a fixed number and put the scan data to the nearest slots. The final data size is calculated by the number of modes of the lidar scan size and the angle increment value 
calculation references the `slam_toolbox` to meet its needs.  

---

此pull request为如以下问题的解决方案参考：
https://github.com/SteveMacenski/slam_toolbox/issues/63
  
添加参数 `fixed_scan_size` 以将 `scan_size` 和 `angle_increasement` 限制为一个固定数字，并将扫描数据放到最近的栏位中。最终的数据大小由激光雷达扫描大小的众数计算得出，角度增量值的计算则参考 `slam_toolbox` 以满足其需要。